### PR TITLE
Deployment: Remove Google Cloud deployment details

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -8,6 +8,5 @@ SV_ANNOTATION_DATA_FILE=data/sv_annotations.tsv
 GENE_EXON_DATA_FILE=data/MANE.GRCh38.v1.0.ensembl_genomic.gtf
 PLINK_FILE_SEARCH_PATTERN=data/LD/*_ld_stats.txt
 ALLELE_FILE_SEARCH_PATTERN=data/LD/*_allele_freq.txt
-GOOGLE_SERVICE_ACCOUNT_JSON_FILE=./sa.json
 PORT=8080
 DOCKER_HOST_PORT=18080  # Only for Docker Compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@
 ##### Approach: Debian #####
 FROM debian:bookworm
 
-ENV GCSFUSE_REPO gcsfuse-bookworm
-ENV GOOGLE_REPO_KEY_FILE "/usr/share/keyrings/cloud.google.asc"
-
 RUN apt update \
     && apt install -qy \
         apt-transport-https \
@@ -16,14 +13,6 @@ RUN apt update \
         python3 \
         python3-dev \
         python3-pip
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee ${GOOGLE_REPO_KEY_FILE}
-RUN echo "deb [signed-by=${GOOGLE_REPO_KEY_FILE}] https://packages.cloud.google.com/apt cloud-sdk main" \
-    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-# RUN echo "deb [signed-by=${GOOGLE_REPO_KEY_FILE}] https://packages.cloud.google.com/apt $GCSFUSE_REPO main" \
-#     | tee /etc/apt/sources.list.d/gcsfuse.list
-RUN apt update \
-    && apt install -qy \
-        google-cloud-cli
 
 ##### Approach: ALL #####
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,13 @@
 version: '3'
 services:
   app:
-    image: shalvichirmade/gwas-svatalog
+    image: strug-hub/gwas-svatalog
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: dnastack.sickkids.gwas-svatalog
+    container_name: sickkids.gwas-svatalog
     env_file: .env
-    environment:
-      - GOOGLE_APPLICATION_CREDENTIALS=/etc/sa.json
     volumes:
-      - './sa.json:/etc/sa.json:ro'
+      - ./data:/app/data
     ports:
       - '${DOCKER_HOST_PORT}:${PORT}'

--- a/startup
+++ b/startup
@@ -4,20 +4,8 @@ set -x
 
 export DATA_DIR=$(pwd)/data
 
-if [ -n "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
-    echo "Authorizing with the given JSON key..."
-    gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
-    echo "The client is now authorized."
-else
-    echo "Use the default service account if running in the cloud."
-fi
-
-gcloud auth list
-
 mkdir -p ${DATA_DIR}
 # chmod g+w ${DATA_DIR}
-
-gsutil cp -r "gs://sickkids-strug-lab-svatalog-data/*" $DATA_DIR
 
 # su app -c 'ls -R /app';
 


### PR DESCRIPTION
Removes any Google Cloud deployment details from the Docker Compose file, Dockerfile, etc. so that we can run the Docker container locally without a Google Cloud account